### PR TITLE
Generic export values in submit.sh.epp template

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,8 +6,7 @@ jupyterhub::batchspawner::version: 1.2.0
 jupyterhub::slurmformspawner::version: 2.3.0
 jupyterhub::jupyterlab::version: 3.4.8
 jupyterhub::jupyterlmod::version: 4.0.1
-jupyterhub::jupyterlab_nvdashboard::version: 0.7.0
-jupyterhub::jupyterlab_nvdashboard::url: https://github.com/cmd-ntrf/jupyterlab-nvdashboard/archive/refs/heads/serverapp_setup.zip
+jupyterhub::jupyterlab_nvdashboard::version: 0.8.0
 jupyterhub::bokeh::version: 2.4.3
 jupyterhub::jupyter_server_proxy::version: 3.2.2
 jupyterhub::jupyter_rsession_proxy::version: 2.1.0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -268,6 +268,7 @@ class jupyterhub (
   $kernel_setup = lookup('jupyterhub::kernel::setup', Enum['venv', 'module'], undef, 'venv')
   $module_list = lookup('jupyterhub::kernel::module::list', Array[String], undef, [])
   $venv_prefix = lookup('jupyterhub::kernel::venv::prefix', String, undef, '/opt/ipython-kernel')
+  $submit_export = lookup('jupyterhub::submit::export', Hash[String, Any], undef, {})
   file { 'submit.sh':
     path    => '/etc/jupyterhub/submit.sh',
     content => epp('jupyterhub/submit.sh', {
@@ -276,6 +277,7 @@ class jupyterhub (
         'node_prefix'      => $node_prefix,
         'venv_prefix'      => $venv_prefix,
         'slurm_partitions' => join($slurm_partitions, ','),
+        'export_vals'      => $submit_export,
     }),
     mode    => '0644',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -268,7 +268,7 @@ class jupyterhub (
   $kernel_setup = lookup('jupyterhub::kernel::setup', Enum['venv', 'module'], undef, 'venv')
   $module_list = lookup('jupyterhub::kernel::module::list', Array[String], undef, [])
   $venv_prefix = lookup('jupyterhub::kernel::venv::prefix', String, undef, '/opt/ipython-kernel')
-  $submit_export = lookup('jupyterhub::submit::export', Hash[String, Any], undef, {})
+  $submit_additions = lookup('jupyterhub::submit::additions', String, undef, '')
   file { 'submit.sh':
     path    => '/etc/jupyterhub/submit.sh',
     content => epp('jupyterhub/submit.sh', {
@@ -277,7 +277,7 @@ class jupyterhub (
         'node_prefix'      => $node_prefix,
         'venv_prefix'      => $venv_prefix,
         'slurm_partitions' => join($slurm_partitions, ','),
-        'export_vals'      => $submit_export,
+        'additions'        => $submit_additions,
     }),
     mode    => '0644',
   }

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -31,7 +31,6 @@ class jupyterhub::node::install (Stdlib::Absolutepath $prefix) {
   $jupyterlmod_version = lookup('jupyterhub::jupyterlmod::version')
   $bokeh_version = lookup('jupyterhub::bokeh::version')
   $jupyterlab_nvdashboard_version = lookup('jupyterhub::jupyterlab_nvdashboard::version')
-  $jupyterlab_nvdashboard_url = lookup('jupyterhub::jupyterlab_nvdashboard::url')
   $jupyter_rsession_proxy_version = lookup('jupyterhub::jupyter_rsession_proxy::version')
   $jupyter_desktop_server_url = lookup('jupyterhub::jupyter_desktop_server::url')
   $python3_version = lookup('jupyterhub::python3::version')
@@ -46,7 +45,6 @@ class jupyterhub::node::install (Stdlib::Absolutepath $prefix) {
         'jupyterlmod_version'            => $jupyterlmod_version,
         'bokeh_version'                  => $bokeh_version,
         'jupyterlab_nvdashboard_version' => $jupyterlab_nvdashboard_version,
-        'jupyterlab_nvdashboard_url'     => $jupyterlab_nvdashboard_url,
         'jupyter_rsession_proxy_version' => $jupyter_rsession_proxy_version,
         'jupyter_desktop_server_url'     => $jupyter_desktop_server_url,
     }),

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "puppet-jupyterhub",
-    "version": "4.6.0",
+    "version": "4.6.1",
     "author": "Félix-Antoine Fortin",
     "summary": "Install, configure, and manage JupyterHub with slurmformspawner",
     "license": "MIT",

--- a/templates/node-requirements.txt.epp
+++ b/templates/node-requirements.txt.epp
@@ -5,7 +5,7 @@ jupyter-rsession-proxy==<%= $jupyter_rsession_proxy_version %>
 jupyter-server-proxy==<%= $jupyter_server_proxy_version %>
 jupyterhub==<%= $jupyterhub_version %>
 jupyterlab==<%= $jupyterlab_version %>
-jupyterlab-nvdashboard @ <%= $jupyterlab_nvdashboard_url %>
+jupyterlab-nvdashboard==<%= $jupyterlab_nvdashboard_version %>
 jupyterlmod==<%= $jupyterlmod_version %>
 notebook==<%= $notebook_version %>
 

--- a/templates/submit.sh.epp
+++ b/templates/submit.sh.epp
@@ -14,6 +14,7 @@
 #SBATCH --partition=<%= $slurm_partitions %>
 <% } %>
 
+<% if $export_vals == {} { %>
 unset XDG_RUNTIME_DIR
 
 # Disable variable export with sbatch
@@ -32,6 +33,11 @@ export PYTHONPATH=${PYTHONPATH}:"<%= $node_prefix %>/lib/usercustomize"
 # Jupyter core is trying to be smart with virtual environments
 # and it is not doing the right thing in our case.
 export JUPYTER_PREFER_ENV_PATH=0
+<% } %>
+
+<% $export_vals.each |$key, $value| { %>
+export <%= $key -%>=<%=$value -%>
+<% } %>
 
 {% if modules %}
 module load {{modules|join(' ')}}

--- a/templates/submit.sh.epp
+++ b/templates/submit.sh.epp
@@ -14,7 +14,8 @@
 #SBATCH --partition=<%= $slurm_partitions %>
 <% } %>
 
-<% if $export_vals == {} { %>
+<%# default behaviour if no additions are provided -%>
+<% if $additions == '' { %>
 unset XDG_RUNTIME_DIR
 
 # Disable variable export with sbatch
@@ -35,9 +36,8 @@ export PYTHONPATH=${PYTHONPATH}:"<%= $node_prefix %>/lib/usercustomize"
 export JUPYTER_PREFER_ENV_PATH=0
 <% } %>
 
-<% $export_vals.each |$key, $value| { %>
-export <%= $key -%>=<%=$value -%>
-<% } %>
+<%# write any additional script here -%>
+<%= $additions -%>
 
 {% if modules %}
 module load {{modules|join(' ')}}


### PR DESCRIPTION
- add option to additional script from hierdata to the submit.sh.epp template with `jupyter::submit::additions`
- if nothing is provided in hierdata, default values are used

### default submit.sh
```sh
#!/bin/bash
{% if account %}#SBATCH --account={{account}}{% endif %}
#SBATCH --time={{runtime}}
#SBATCH --output={{homedir}}/.jupyterhub_slurmspawner_%j.log
#SBATCH --job-name=spawner-jupyterhub
#SBATCH --chdir={{homedir}}
#SBATCH --mem={{memory}}
#SBATCH --cpus-per-task={{nprocs}}
#SBATCH --export={{keepvars}}
{% if oversubscribe %}#SBATCH --oversubscribe{% endif %}
{% if reservation %}#SBATCH --reservation={{reservation}}{% endif %}
{% if gpus != "gpu:0" %}#SBATCH --gres={{gpus}}{% endif %}



unset XDG_RUNTIME_DIR

# Disable variable export with sbatch
export SBATCH_EXPORT=NONE
# Avoid steps inheriting environment export
# settings from the sbatch command
unset SLURM_EXPORT_ENV

# Setup user pip install folder
export PIP_PREFIX=${SLURM_TMPDIR}
export PATH="${PIP_PREFIX}/bin":${PATH}
export PYTHONPATH=${PYTHONPATH}:"/opt/jupyterhub/lib/usercustomize"

# Make sure the environment-level directories does not
# have priority over user-level directories for config and data.
# Jupyter core is trying to be smart with virtual environments
# and it is not doing the right thing in our case.
export JUPYTER_PREFER_ENV_PATH=0



{% if modules %}
module load {{modules|join(' ')}}
{% endif %}



# Launch jupyterhub single server
{{cmd}}
```

### submit.sh with additions defined
```yaml
jupyterhub::submit::additions: |
  unset XDG_RUNTIME_DIR

  # Disable variable export with sbatch
  export SBATCH_EXPORT=NONE
  # Avoid steps inheriting environment export
  # settings from the sbatch command
  unset SLURM_EXPORT_ENV

  # Setup user pip install folder
  export PIP_PREFIX=${SLURM_TMPDIR}
  export PATH="${PIP_PREFIX}/bin":${PATH}
  export PYTHONPATH=${PYTHONPATH}:"/opt/jupyterhub/lib/usercustomize"

  # Make sure the environment-level directories does not
  # have priority over user-level directories for config and data.
  # Jupyter core is trying to be smart with virtual environments
  # and it is not doing the right thing in our case.
  export JUPYTER_PREFER_ENV_PATH=0

  # here's a comment to make this different
```

```sh
#!/bin/bash
{% if account %}#SBATCH --account={{account}}{% endif %}
#SBATCH --time={{runtime}}
#SBATCH --output={{homedir}}/.jupyterhub_slurmspawner_%j.log
#SBATCH --job-name=spawner-jupyterhub
#SBATCH --chdir={{homedir}}
#SBATCH --mem={{memory}}
#SBATCH --cpus-per-task={{nprocs}}
#SBATCH --export={{keepvars}}
{% if oversubscribe %}#SBATCH --oversubscribe{% endif %}
{% if reservation %}#SBATCH --reservation={{reservation}}{% endif %}
{% if gpus != "gpu:0" %}#SBATCH --gres={{gpus}}{% endif %}




unset XDG_RUNTIME_DIR

# Disable variable export with sbatch
export SBATCH_EXPORT=NONE
# Avoid steps inheriting environment export
# settings from the sbatch command
unset SLURM_EXPORT_ENV

# Setup user pip install folder
export PIP_PREFIX=${SLURM_TMPDIR}
export PATH="${PIP_PREFIX}/bin":${PATH}
export PYTHONPATH=${PYTHONPATH}:"/opt/jupyterhub/lib/usercustomize"

# Make sure the environment-level directories does not
# have priority over user-level directories for config and data.
# Jupyter core is trying to be smart with virtual environments
# and it is not doing the right thing in our case.
export JUPYTER_PREFER_ENV_PATH=0

# here's a comment to make this different

{% if modules %}
module load {{modules|join(' ')}}
{% endif %}



# Launch jupyterhub single server
{{cmd}}
```