### PR TITLE
Generic export values in submit.sh.epp template

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,8 @@ jupyterhub::jupyter_notebook_config_hash:
 | `jupyterhub::oauthenticator::scope` | Array[String] | OIDC scope | |
 | `jupyterhub::oauthenticator::allowed_groups` | Array[String] | List of groups who should be allowed to connect. Empty list = any group | [] |
 | `jupyterhub::oauthenticator::claim_groups_key` | String | Userdata groups claim key from returned  OIDC json | 'affiliation' |
+
+### Other options
+| Variable | Type | Description | Default |
+| -------- | :----| :-----------| ------- |
+| `jupyterhub::submit::additions` | String | Script that should be added to submit.sh | |

--- a/README.md
+++ b/README.md
@@ -245,7 +245,29 @@ jupyterhub::jupyter_notebook_config_hash:
 | `jupyterhub::oauthenticator::allowed_groups` | Array[String] | List of groups who should be allowed to connect. Empty list = any group | [] |
 | `jupyterhub::oauthenticator::claim_groups_key` | String | Userdata groups claim key from returned  OIDC json | 'affiliation' |
 
-### Other options
-| Variable | Type | Description | Default |
-| -------- | :----| :-----------| ------- |
-| `jupyterhub::submit::additions` | String | Script that should be added to submit.sh | |
+### Submit addition option
+| Variable | Type | Description |
+| -------- | :----| :-----------|
+| `jupyterhub::submit::additions` | String | Script that should be added to submit.sh |
+
+Adds the following by default:
+```sh
+unset XDG_RUNTIME_DIR
+
+# Disable variable export with sbatch
+export SBATCH_EXPORT=NONE
+# Avoid steps inheriting environment export
+# settings from the sbatch command
+unset SLURM_EXPORT_ENV
+
+# Setup user pip install folder
+export PIP_PREFIX=${SLURM_TMPDIR}
+export PATH="${PIP_PREFIX}/bin":${PATH}
+export PYTHONPATH=${PYTHONPATH}:"/opt/jupyterhub/lib/usercustomize"
+
+# Make sure the environment-level directories does not
+# have priority over user-level directories for config and data.
+# Jupyter core is trying to be smart with virtual environments
+# and it is not doing the right thing in our case.
+export JUPYTER_PREFER_ENV_PATH=0
+```

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ jupyterhub::jupyter_notebook_config_hash:
 ### Submit addition option
 | Variable | Type | Description |
 | -------- | :----| :-----------|
-| `jupyterhub::submit::additions` | String | Script that should be added to submit.sh |
+| `jupyterhub::submit::additions` | String | bash command(s) that should be added to submit.sh |
 
 Adds the following by default:
 ```sh

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -268,6 +268,7 @@ class jupyterhub (
   $kernel_setup = lookup('jupyterhub::kernel::setup', Enum['venv', 'module'], undef, 'venv')
   $module_list = lookup('jupyterhub::kernel::module::list', Array[String], undef, [])
   $venv_prefix = lookup('jupyterhub::kernel::venv::prefix', String, undef, '/opt/ipython-kernel')
+  $submit_export = lookup('jupyterhub::submit::export', Hash[String, Any], undef, {})
   file { 'submit.sh':
     path    => '/etc/jupyterhub/submit.sh',
     content => epp('jupyterhub/submit.sh', {
@@ -276,6 +277,7 @@ class jupyterhub (
         'node_prefix'      => $node_prefix,
         'venv_prefix'      => $venv_prefix,
         'slurm_partitions' => join($slurm_partitions, ','),
+        'export_vals'      => $submit_export,
     }),
     mode    => '0644',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -268,7 +268,7 @@ class jupyterhub (
   $kernel_setup = lookup('jupyterhub::kernel::setup', Enum['venv', 'module'], undef, 'venv')
   $module_list = lookup('jupyterhub::kernel::module::list', Array[String], undef, [])
   $venv_prefix = lookup('jupyterhub::kernel::venv::prefix', String, undef, '/opt/ipython-kernel')
-  $submit_export = lookup('jupyterhub::submit::export', Hash[String, Any], undef, {})
+  $submit_additions = lookup('jupyterhub::submit::additions', String, undef, '')
   file { 'submit.sh':
     path    => '/etc/jupyterhub/submit.sh',
     content => epp('jupyterhub/submit.sh', {
@@ -277,7 +277,7 @@ class jupyterhub (
         'node_prefix'      => $node_prefix,
         'venv_prefix'      => $venv_prefix,
         'slurm_partitions' => join($slurm_partitions, ','),
-        'export_vals'      => $submit_export,
+        'additions'        => $submit_additions,
     }),
     mode    => '0644',
   }

--- a/templates/submit.sh.epp
+++ b/templates/submit.sh.epp
@@ -14,6 +14,7 @@
 #SBATCH --partition=<%= $slurm_partitions %>
 <% } %>
 
+<% if $export_vals == {} { %>
 unset XDG_RUNTIME_DIR
 
 # Disable variable export with sbatch
@@ -32,6 +33,11 @@ export PYTHONPATH=${PYTHONPATH}:"<%= $node_prefix %>/lib/usercustomize"
 # Jupyter core is trying to be smart with virtual environments
 # and it is not doing the right thing in our case.
 export JUPYTER_PREFER_ENV_PATH=0
+<% } %>
+
+<% $export_vals.each |$key, $value| { %>
+export <%= $key -%>=<%=$value -%>
+<% } %>
 
 {% if modules %}
 module load {{modules|join(' ')}}

--- a/templates/submit.sh.epp
+++ b/templates/submit.sh.epp
@@ -14,7 +14,8 @@
 #SBATCH --partition=<%= $slurm_partitions %>
 <% } %>
 
-<% if $export_vals == {} { %>
+<%# default behaviour if no additions are provided -%>
+<% if $additions == '' { %>
 unset XDG_RUNTIME_DIR
 
 # Disable variable export with sbatch
@@ -35,9 +36,8 @@ export PYTHONPATH=${PYTHONPATH}:"<%= $node_prefix %>/lib/usercustomize"
 export JUPYTER_PREFER_ENV_PATH=0
 <% } %>
 
-<% $export_vals.each |$key, $value| { %>
-export <%= $key -%>=<%=$value -%>
-<% } %>
+<%# write any additional script here -%>
+<%= $additions -%>
 
 {% if modules %}
 module load {{modules|join(' ')}}


### PR DESCRIPTION
- add option to additional script from hierdata to the submit.sh.epp template with `jupyter::submit::additions`
- if nothing is provided in hierdata, default values are used

### default submit.sh
```sh
#!/bin/bash
{% if account %}#SBATCH --account={{account}}{% endif %}
#SBATCH --time={{runtime}}
#SBATCH --output={{homedir}}/.jupyterhub_slurmspawner_%j.log
#SBATCH --job-name=spawner-jupyterhub
#SBATCH --chdir={{homedir}}
#SBATCH --mem={{memory}}
#SBATCH --cpus-per-task={{nprocs}}
#SBATCH --export={{keepvars}}
{% if oversubscribe %}#SBATCH --oversubscribe{% endif %}
{% if reservation %}#SBATCH --reservation={{reservation}}{% endif %}
{% if gpus != "gpu:0" %}#SBATCH --gres={{gpus}}{% endif %}



unset XDG_RUNTIME_DIR

# Disable variable export with sbatch
export SBATCH_EXPORT=NONE
# Avoid steps inheriting environment export
# settings from the sbatch command
unset SLURM_EXPORT_ENV

# Setup user pip install folder
export PIP_PREFIX=${SLURM_TMPDIR}
export PATH="${PIP_PREFIX}/bin":${PATH}
export PYTHONPATH=${PYTHONPATH}:"/opt/jupyterhub/lib/usercustomize"

# Make sure the environment-level directories does not
# have priority over user-level directories for config and data.
# Jupyter core is trying to be smart with virtual environments
# and it is not doing the right thing in our case.
export JUPYTER_PREFER_ENV_PATH=0



{% if modules %}
module load {{modules|join(' ')}}
{% endif %}



# Launch jupyterhub single server
{{cmd}}
```

### submit.sh with additions defined
```yaml
jupyterhub::submit::additions: |
  unset XDG_RUNTIME_DIR

  # Disable variable export with sbatch
  export SBATCH_EXPORT=NONE
  # Avoid steps inheriting environment export
  # settings from the sbatch command
  unset SLURM_EXPORT_ENV

  # Setup user pip install folder
  export PIP_PREFIX=${SLURM_TMPDIR}
  export PATH="${PIP_PREFIX}/bin":${PATH}
  export PYTHONPATH=${PYTHONPATH}:"/opt/jupyterhub/lib/usercustomize"

  # Make sure the environment-level directories does not
  # have priority over user-level directories for config and data.
  # Jupyter core is trying to be smart with virtual environments
  # and it is not doing the right thing in our case.
  export JUPYTER_PREFER_ENV_PATH=0

  # here's a comment to make this different
```

```sh
#!/bin/bash
{% if account %}#SBATCH --account={{account}}{% endif %}
#SBATCH --time={{runtime}}
#SBATCH --output={{homedir}}/.jupyterhub_slurmspawner_%j.log
#SBATCH --job-name=spawner-jupyterhub
#SBATCH --chdir={{homedir}}
#SBATCH --mem={{memory}}
#SBATCH --cpus-per-task={{nprocs}}
#SBATCH --export={{keepvars}}
{% if oversubscribe %}#SBATCH --oversubscribe{% endif %}
{% if reservation %}#SBATCH --reservation={{reservation}}{% endif %}
{% if gpus != "gpu:0" %}#SBATCH --gres={{gpus}}{% endif %}




unset XDG_RUNTIME_DIR

# Disable variable export with sbatch
export SBATCH_EXPORT=NONE
# Avoid steps inheriting environment export
# settings from the sbatch command
unset SLURM_EXPORT_ENV

# Setup user pip install folder
export PIP_PREFIX=${SLURM_TMPDIR}
export PATH="${PIP_PREFIX}/bin":${PATH}
export PYTHONPATH=${PYTHONPATH}:"/opt/jupyterhub/lib/usercustomize"

# Make sure the environment-level directories does not
# have priority over user-level directories for config and data.
# Jupyter core is trying to be smart with virtual environments
# and it is not doing the right thing in our case.
export JUPYTER_PREFER_ENV_PATH=0

# here's a comment to make this different

{% if modules %}
module load {{modules|join(' ')}}
{% endif %}



# Launch jupyterhub single server
{{cmd}}
```