### PR TITLE
update jupyterhub to 4.x

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,14 +1,14 @@
 # jupyterhub/data/common.yaml
 ---
 jupyterhub::notebook::version: 6.4.12
-jupyterhub::jupyterhub::version: 2.3.1
+jupyterhub::jupyterhub::version: 4.0.2
 jupyterhub::pamela::version: 1.1.0
-jupyterhub::batchspawner::version: 1.2.0
+jupyterhub::batchspawner::version: 1.2.0 # this is currently ignored on nodes
 jupyterhub::slurmformspawner::version: 2.5.0
 jupyterhub::jupyterhub_traefik_proxy::version: 1.1.0
-jupyterhub::jupyterlab::version: 3.4.8
+jupyterhub::jupyterlab::version: 4.1.0
 jupyterhub::jupyterlmod::version: 4.0.1
-jupyterhub::jupyterlab_nvdashboard::version: 0.8.0
+jupyterhub::jupyterlab_nvdashboard::version: 0.8.0 # this is currently ignored
 jupyterhub::bokeh::version: 2.4.3
 jupyterhub::jupyter_server_proxy::version: 3.2.2
 jupyterhub::jupyter_rsession_proxy::version: 2.1.0

--- a/templates/hub-requirements.txt.epp
+++ b/templates/hub-requirements.txt.epp
@@ -4,9 +4,11 @@ jupyterhub-idle-culler==<%= $idle_culler_version %>
 jupyterhub-announcement @ https://github.com/rcthomas/jupyterhub-announcement/archive/refs/tags/<%= $announcement_version %>.zip
 slurmformspawner==<%= $slurmformspawner_version %>
 jupyterhub-traefik-proxy==<%= $jupyterhub_traefik_proxy_version %>
+jupyterlab==<%= $jupyterlab_version %>
 aiohttp==3.8.5
 aiosignal==1.3.1
 alembic==1.9.2
+anyio==3.1.0
 async-generator==1.10
 async-timeout==4.0.3
 attrs==22.2.0
@@ -22,9 +24,12 @@ escapism==1.0.1
 frozenlist==1.4.0
 greenlet==2.0.2
 html-sanitizer==1.9.3
+httpx==0.27.0
 idna==3.4
 Jinja2==3.1.2
-jsonschema==4.17.3
+jsonschema==4.18.0
+jupyter_core==5.7.1
+jupyter-server==2.4.0
 jupyter-telemetry==0.1.0
 lxml==4.9.2
 Mako==1.2.4

--- a/templates/node-requirements.txt.epp
+++ b/templates/node-requirements.txt.epp
@@ -1,13 +1,19 @@
-batchspawner==<%= $batchspawner_version %>
 bokeh==<%= $bokeh_version %>
 jupyter-desktop-server @ <%= $jupyter_desktop_server_url %>
 jupyter-rsession-proxy==<%= $jupyter_rsession_proxy_version %>
 jupyter-server-proxy==<%= $jupyter_server_proxy_version %>
 jupyterhub==<%= $jupyterhub_version %>
 jupyterlab==<%= $jupyterlab_version %>
-jupyterlab-nvdashboard==<%= $jupyterlab_nvdashboard_version %>
 jupyterlmod==<%= $jupyterlmod_version %>
 notebook==<%= $notebook_version %>
+
+# batchspawner has no releases that support jupyterlab 4.x
+# batchspawner==<%= $batchspawner_version %>
+batchspawner @ git+https://github.com/jupyterhub/batchspawner.git@e2f3440bc1478f47fe4592d67f4bf364265cec1c
+
+# jupyterlab-nvdashboard does not currently support jupyterlab 4.x
+# removed as it is not strictly necessary
+# jupyterlab-nvdashboard==<%= $jupyterlab_nvdashboard_version %>
 
 aiohttp==3.8.3
 aiosignal==1.3.1
@@ -43,7 +49,7 @@ ipython-genutils==0.2.0
 Jinja2==3.1.2
 json5==0.9.11
 jsonschema==4.17.3
-jupyter-server==1.23.5
+jupyter-server==2.4.0
 jupyter-telemetry==0.1.0
 jupyter_client==8.0.2
 jupyter_core==5.2.0


### PR DESCRIPTION
update the necessary packages to make newer jupyterhub versions work. One package had to be removed as it has no support for 4.x versions of jupyterhub and another had to switch to use commits.